### PR TITLE
chore: add linting and CI tooling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: |
+          pytest tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+   # https://github.com/pre-commit/pre-commit-hooks#pre-commit-hooks
+   - repo: https://github.com/pre-commit/pre-commit-hooks
+     rev: v4.6.0
+     hooks:
+       - id: check-yaml
+       - id: end-of-file-fixer
+       - id: trailing-whitespace
+       - id: check-added-large-files
+
+   - repo: https://github.com/astral-sh/ruff-pre-commit
+     rev: v0.5.1 # Ruff version
+     hooks:
+       - id: ruff
+         args: [--fix, --exit-non-zero-on-fix]
+       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ python cli.py load
 
 It will download the catalog from data.gouv.fr and update or create the rows in the various tables. Metrics will be computed for the current day (run it multiple days in a row to have historical depth).
 
+## Linting
+
+Linting, formatting and import sorting are done automatically by [Ruff](https://docs.astral.sh/ruff/) launched by a pre-commit hook. So, before contributing to the repository, it is necessary to initialize the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+Once this is done, code formatting and linting, as well as import sorting, will be automatically checked before each commit.
+
+If you cannot use pre-commit, it is necessary to format, lint, and sort imports with [Ruff](https://docs.astral.sh/ruff/) before committing:
+
+```bash
+ruff check --fix .
+ruff format .
+```
+
+> WARNING: running `ruff` on the codebase will lint and format all of it, whereas using `pre-commit` will only be done on the staged files
+
 ## Dokku
 
 Published on http://ecospheres-catalog-scripts.app.france.sh (dummy page).

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 def application(environ, start_response):
     data = b"ok"
-    status = '200 OK'
-    headers = [('Content-type', 'text/plain; charset=utf-8'),
-               ('Content-Length', str(len(data)))]
+    status = "200 OK"
+    headers = [("Content-type", "text/plain; charset=utf-8"), ("Content-Length", str(len(data)))]
     start_response(status, headers)
     return iter([data])

--- a/cli.py
+++ b/cli.py
@@ -1,16 +1,14 @@
 import math
 import time
-
-from datetime import date
 from collections import defaultdict
+from datetime import date
 
 import requests
-
 from minicli import cli, run
 from sqlalchemy.types import Float
 
-from db import get_table, query, get_tables
-from models import Organization, Dataset, DatasetBouquet, Rel, Resource, Bouquet
+from db import get_table, get_tables, query
+from models import Bouquet, Dataset, DatasetBouquet, Organization, Rel, Resource
 
 
 def get_prefix_from_env(env: str):
@@ -85,9 +83,11 @@ def load_bouquets(
     if include_private:
         url = f"{url}&include_private=yes"
 
-    for bouquet in iter_rel({
-        "href": url,
-    }):
+    for bouquet in iter_rel(
+        {
+            "href": url,
+        }
+    ):
         bouquets.upsert(Bouquet.from_payload(bouquet), ["bouquet_id"])
         datasets_bouquets.insert_many(DatasetBouquet.from_payload(bouquet, catalog))
 
@@ -152,12 +152,16 @@ def compute_metrics():
         value: int,
         organization: str | None = None,
     ):
-        metrics.upsert({
-            "date": at,
-            "measurement": measurement,
-            "value": value,
-            "organization": organization,
-        }, ["date", "measurement", "organization"], types={"value": Float})
+        metrics.upsert(
+            {
+                "date": at,
+                "measurement": measurement,
+                "value": value,
+                "organization": organization,
+            },
+            ["date", "measurement", "organization"],
+            types={"value": Float},
+        )
 
     organizations = [r["organization"] for r in catalog.distinct("organization", deleted=False)]
     add_metric("nb_organizations", len(organizations))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 pytest
+pre-commit
+ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+line-length = 100
+
+[lint]
+extend-select = ["I"] # also sort imports with an isort rule

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,19 +1,20 @@
 import os
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import patch, Mock
+
 from db import get, get_table
 
 
-@patch('db.get_db', Mock(return_value=True))
+@patch("db.get_db", Mock(return_value=True))
 def test_get_return_db_if_it_truthy():
     assert get() is True
 
 
-@patch('dataset.connect', Mock(return_value={'database': True}))
+@patch("dataset.connect", Mock(return_value={"database": True}))
 def test_get_return_fresh_db():
-    os.environ['DATABASE_URL'] = 'some'
-    assert get() == {'database': True}
+    os.environ["DATABASE_URL"] = "some"
+    assert get() == {"database": True}
 
 
 def test_get_table_raise_if_received_none():
@@ -21,15 +22,15 @@ def test_get_table_raise_if_received_none():
         def get_table(table_name: str):
             return None
 
-    with patch('db.get', return_value=Mock):
+    with patch("db.get", return_value=Mock):
         with pytest.raises(ValueError):
-            get_table('table_name')
+            get_table("table_name")
 
 
 def test_get_table_return():
     class Mock:
         def get_table(table_name: str):
-            return {'table': True}
+            return {"table": True}
 
-    with patch('db.get', return_value=Mock):
-        assert get_table('table_name') == {'table': True}
+    with patch("db.get", return_value=Mock):
+        assert get_table("table_name") == {"table": True}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,212 +2,175 @@ from models import BaseModel
 
 
 def test_base_model_get_attr_by_path_return_none_on_keyerror():
-    base = BaseModel({'some': {'another_path': 2}}, prefix='test')
+    base = BaseModel({"some": {"another_path": 2}}, prefix="test")
 
-    assert base.get_attr_by_path('some__path') is None
+    assert base.get_attr_by_path("some__path") is None
 
 
 def test_base_model_get_attr_by_path_ignore_none_value():
-    base = BaseModel({'some': {'path': None}}, prefix='test')
+    base = BaseModel({"some": {"path": None}}, prefix="test")
 
-    assert base.get_attr_by_path('some__path') is None
+    assert base.get_attr_by_path("some__path") is None
 
 
 def test_base_model_get_attr_by_path_find_sub_property():
-    base = BaseModel({'foo': {'bar': 1}}, prefix='test')
+    base = BaseModel({"foo": {"bar": 1}}, prefix="test")
 
-    assert base.get_attr_by_path('foo__bar') == 1
+    assert base.get_attr_by_path("foo__bar") == 1
 
 
 def test_base_model_get_indicators_false():
-    base = BaseModel({'column_false': None}, prefix='test')
-    base.indicators = [
-        {'id': 'column_false', "not": None}
-    ]
+    base = BaseModel({"column_false": None}, prefix="test")
+    base.indicators = [{"id": "column_false", "not": None}]
 
-    assert base.get_indicators() == {'has_column_false': False}
+    assert base.get_indicators() == {"has_column_false": False}
 
-    base = BaseModel({'column_false': True}, prefix='test')
-    base.indicators = [
-        {'id': 'column_false', "not": True}
-    ]
+    base = BaseModel({"column_false": True}, prefix="test")
+    base.indicators = [{"id": "column_false", "not": True}]
 
-    assert base.get_indicators() == {'has_column_false': False}
+    assert base.get_indicators() == {"has_column_false": False}
 
-    base = BaseModel({'column_false': 'specific string'}, prefix='test')
-    base.indicators = [
-        {'id': 'column_false', "not": 'specific string'}
-    ]
+    base = BaseModel({"column_false": "specific string"}, prefix="test")
+    base.indicators = [{"id": "column_false", "not": "specific string"}]
 
-    assert base.get_indicators() == {'has_column_false': False}
+    assert base.get_indicators() == {"has_column_false": False}
 
-    base = BaseModel({'column_false': []}, prefix='test')
-    base.indicators = [
-        {'id': 'column_false', "not": [[], None]}
-    ]
+    base = BaseModel({"column_false": []}, prefix="test")
+    base.indicators = [{"id": "column_false", "not": [[], None]}]
 
-    assert base.get_indicators() == {'has_column_false': False}
+    assert base.get_indicators() == {"has_column_false": False}
 
-    base = BaseModel({'column_false': None}, prefix='test')
-    base.indicators = [
-        {'id': 'column_false', "not": [[], None]}
-    ]
+    base = BaseModel({"column_false": None}, prefix="test")
+    base.indicators = [{"id": "column_false", "not": [[], None]}]
 
-    assert base.get_indicators() == {'has_column_false': False}
+    assert base.get_indicators() == {"has_column_false": False}
 
 
 def test_base_model_get_indicators_true():
-    base = BaseModel({'column_one': 'some value'}, prefix='test')
-    base.indicators = [
-        {'id': 'column_one', "not": None}
-    ]
+    base = BaseModel({"column_one": "some value"}, prefix="test")
+    base.indicators = [{"id": "column_one", "not": None}]
 
-    assert base.get_indicators() == {'has_column_one': True}
+    assert base.get_indicators() == {"has_column_one": True}
 
-    base = BaseModel({'column_one': ''}, prefix='test')
-    base.indicators = [
-        {'id': 'column_one', "not": None}
-    ]
+    base = BaseModel({"column_one": ""}, prefix="test")
+    base.indicators = [{"id": "column_one", "not": None}]
 
-    assert base.get_indicators() == {'has_column_one': True}
+    assert base.get_indicators() == {"has_column_one": True}
 
-    base = BaseModel({'column_one': 0}, prefix='test')
-    base.indicators = [
-        {'id': 'column_one', "not": None}
-    ]
+    base = BaseModel({"column_one": 0}, prefix="test")
+    base.indicators = [{"id": "column_one", "not": None}]
 
-    assert base.get_indicators() == {'has_column_one': True}
+    assert base.get_indicators() == {"has_column_one": True}
 
-    base = BaseModel({'column_one': []}, prefix='test')
-    base.indicators = [
-        {'id': 'column_one', "not": None}
-    ]
+    base = BaseModel({"column_one": []}, prefix="test")
+    base.indicators = [{"id": "column_one", "not": None}]
 
-    assert base.get_indicators() == {'has_column_one': True}
+    assert base.get_indicators() == {"has_column_one": True}
 
 
 def test_base_model_get_prefix_or_fallback_from_find_prefix():
-    base = BaseModel({
-        'harvest': {
-            'remote_id': 'https://slug/final'
-        }
-    }, prefix='test')
+    base = BaseModel({"harvest": {"remote_id": "https://slug/final"}}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'https://slug/'
+    assert base.get_prefix_or_fallback_from("remote_id") == "https://slug/"
 
-    base = BaseModel({
-        'harvest': {
-            'remote_id': 'http://slug/final'
-        }
-    }, prefix='test')
+    base = BaseModel({"harvest": {"remote_id": "http://slug/final"}}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'http://slug/'
+    assert base.get_prefix_or_fallback_from("remote_id") == "http://slug/"
 
 
 def test_base_model_get_prefix_or_fallback_from_string_ending_with_slash():
-    base = BaseModel({
-        'harvest': {
-            'remote_id': 'bépobépobépobépo/final'
-        }
-    }, prefix='test')
+    base = BaseModel({"harvest": {"remote_id": "bépobépobépobépo/final"}}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'bépobépobépobépo/'
+    assert base.get_prefix_or_fallback_from("remote_id") == "bépobépobépobépo/"
 
 
 def test_base_model_get_prefix_or_fallback_from_with_none_harvest():
-    base = BaseModel({'harvest': None}, prefix='test')
+    base = BaseModel({"harvest": None}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'Préfixe manquant'
+    assert base.get_prefix_or_fallback_from("remote_id") == "Préfixe manquant"
 
 
 def test_base_model_get_prefix_or_fallback_from_remote_id_missing():
-    base = BaseModel({
-        'harvest': {}
-    }, prefix='test')
+    base = BaseModel({"harvest": {}}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'Préfixe manquant'
+    assert base.get_prefix_or_fallback_from("remote_id") == "Préfixe manquant"
 
 
 def test_base_model_get_prefix_or_fallback_from_harvest_missing():
-    base = BaseModel({}, prefix='test')
+    base = BaseModel({}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'Préfixe manquant'
+    assert base.get_prefix_or_fallback_from("remote_id") == "Préfixe manquant"
 
 
 def test_base_model_get_prefix_or_fallback_from_suffix_missing():
-    base = BaseModel({
-        'harvest': {
-            'remote_id': 'http://slug/'
-        }
-    }, prefix='test')
+    base = BaseModel({"harvest": {"remote_id": "http://slug/"}}, prefix="test")
 
-    assert base.get_prefix_or_fallback_from('remote_id') == 'Préfixe manquant'
+    assert base.get_prefix_or_fallback_from("remote_id") == "Préfixe manquant"
 
 
 def test_base_model_get_url_data_gouv():
-    base = BaseModel({'id': '123456'}, prefix='test')
+    base = BaseModel({"id": "123456"}, prefix="test")
 
     assert base.get_url_data_gouv() == (
-        '<a href="https://test.data.gouv.fr/fr/datasets/123456"'
-        ' target="_blank">123456</a>'
+        '<a href="https://test.data.gouv.fr/fr/datasets/123456"' ' target="_blank">123456</a>'
     )
 
 
 def test_base_model_get_consistent_dates_updated_in_the_future():
-    base = BaseModel({'created_at': '100', 'last_modified': '200'}, prefix='test')
+    base = BaseModel({"created_at": "100", "last_modified": "200"}, prefix="test")
 
     assert base.get_consistent_dates() is True
 
 
 def test_base_model_get_consistent_dates_updated_in_the_past():
-    base = BaseModel({'created_at': '300', 'last_modified': '100'}, prefix='test')
+    base = BaseModel({"created_at": "300", "last_modified": "100"}, prefix="test")
 
     assert base.get_consistent_dates() is False
 
 
 def test_base_model_get_consistent_dates_missing_modified():
-    base = BaseModel({'created_at': '400'}, prefix='test')
+    base = BaseModel({"created_at": "400"}, prefix="test")
 
     assert base.get_consistent_dates() is True
 
 
 def test_base_model_get_consistent_dates_missing_created():
-    base = BaseModel({'last_modified': '400'}, prefix='test')
+    base = BaseModel({"last_modified": "400"}, prefix="test")
 
     assert base.get_consistent_dates() is False
 
 
 def test_base_model_get_consistent_dates_no_dates():
-    base = BaseModel({}, prefix='test')
+    base = BaseModel({}, prefix="test")
 
     assert base.get_consistent_dates() is True
 
 
 def test_base_model_get_consistent_temporal_coverage_end_in_the_future():
-    base = BaseModel({'temporal_coverage': {'start': 1, 'end': 2}}, prefix='test')
+    base = BaseModel({"temporal_coverage": {"start": 1, "end": 2}}, prefix="test")
 
     assert base.get_consistent_temporal_coverage() is True
 
 
 def test_base_model_get_consistent_temporal_coverage_end_in_the_past():
-    base = BaseModel({'temporal_coverage': {'start': 4, 'end': 3}}, prefix='test')
+    base = BaseModel({"temporal_coverage": {"start": 4, "end": 3}}, prefix="test")
 
     assert base.get_consistent_temporal_coverage() is False
 
 
 def test_base_model_get_consistent_temporal_coverage_missing_end():
-    base = BaseModel({'temporal_coverage': {'start': 4}}, prefix='test')
+    base = BaseModel({"temporal_coverage": {"start": 4}}, prefix="test")
 
     assert base.get_consistent_temporal_coverage() is False
 
 
 def test_base_model_get_consistent_temporal_coverage_missing_start():
-    base = BaseModel({'temporal_coverage': {'end': 4}}, prefix='test')
+    base = BaseModel({"temporal_coverage": {"end": 4}}, prefix="test")
 
     assert base.get_consistent_temporal_coverage() is False
 
 
 def test_base_model_get_consistent_temporal_coverage_no_dates():
-    base = BaseModel({'temporal_coverage': {}}, prefix='test')
+    base = BaseModel({"temporal_coverage": {}}, prefix="test")
 
     assert base.get_consistent_temporal_coverage() is True


### PR DESCRIPTION
This adds:
- a linting config based on `ruff` (same as data.gouv.fr and isomorphe)
- a `pre-commit` workflow to auto format the committed files
- a GitHub CI to run the tests on PRs

The formatter/linter has been triggered on all repo files, so this includes fixes.