### PR TITLE
Fix pyright errors and add to pre-commit and workspace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,25 @@
 repos:
-   # https://github.com/pre-commit/pre-commit-hooks#pre-commit-hooks
-   - repo: https://github.com/pre-commit/pre-commit-hooks
-     rev: v4.6.0
-     hooks:
-       - id: check-yaml
-       - id: end-of-file-fixer
-       - id: trailing-whitespace
-       - id: check-added-large-files
+  # https://github.com/pre-commit/pre-commit-hooks#pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
 
-   - repo: https://github.com/astral-sh/ruff-pre-commit
-     rev: v0.5.1 # Ruff version
-     hooks:
-       - id: ruff
-         args: [--fix, --exit-non-zero-on-fix]
-       - id: ruff-format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.1 # Ruff version
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: pyright
+        language: system
+        types: [python]
+        require_serial: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.vscode-pylance"
+    ]
+}

--- a/models.py
+++ b/models.py
@@ -97,9 +97,6 @@ class BaseModel:
     def to_model(self):
         raise NotImplementedError()
 
-    def get_license_title(self, id: str | None) -> str | None:
-        return next((item["title"] for item in self.licenses if item["id"] == id), None)
-
     def to_row(self) -> dict:
         model = self.to_model()
         indicators = self.get_indicators()
@@ -144,6 +141,7 @@ class DatasetRow(TypedDict):
     frequency: str
     temporal_coverage: dict
     license: str
+    license__title: str | None
     quality: dict
     internal: dict
 
@@ -166,6 +164,9 @@ class Dataset(BaseModel):
         {"id": "frequency", "not": [None, "unknown"]},
         {"id": "contact_point", "not": None},
     ]
+
+    def get_license_title(self, id: str | None) -> str | None:
+        return next((item["title"] for item in self.licenses if item["id"] == id), None)
 
     def to_model(self) -> DatasetRow:
         return DatasetRow(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest
 pre-commit
 ruff
+pyright

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,18 +19,18 @@ def test_get_return_fresh_db():
 
 def test_get_table_raise_if_received_none():
     class Mock:
-        def get_table(table_name: str):
+        def get_table(self, table_name: str):
             return None
 
-    with patch("db.get", return_value=Mock):
+    with patch("db.get", return_value=Mock()):
         with pytest.raises(ValueError):
             get_table("table_name")
 
 
 def test_get_table_return():
     class Mock:
-        def get_table(table_name: str):
+        def get_table(self, table_name: str):
             return {"table": True}
 
-    with patch("db.get", return_value=Mock):
+    with patch("db.get", return_value=Mock()):
         assert get_table("table_name") == {"table": True}


### PR DESCRIPTION
#5 a introduit des erreurs de typage. Cette PR les corrige et ajoute un check `pyright` au pre-commit pour éviter que ça se reproduise. Aussi, ajoute l'extension Pylance comme recommandé dans vscode (cf screenshots).

<img width="786" alt="Capture d’écran 2024-10-16 à 14 20 15" src="https://github.com/user-attachments/assets/6e5dd7d8-06e1-43d4-9858-ba367c899e13">

<img width="898" alt="Capture d’écran 2024-10-16 à 14 20 06" src="https://github.com/user-attachments/assets/55a17b52-29ba-41a8-9074-3abee1da45b6">
