### PR TITLE
Fix harvest.* types

### DIFF
--- a/models.py
+++ b/models.py
@@ -109,8 +109,8 @@ class BaseModel:
             "consistent_temporal_coverage": self.get_consistent_temporal_coverage(),
         }
 
-        # TODO: model.pop("harvest")
         harvest = {f"harvest__{key}": val for key, val in model["harvest"].items()}
+        del model["harvest"]
 
         return {**model, **indicators, **computed_columns, **harvest}
 

--- a/models.py
+++ b/models.py
@@ -192,8 +192,10 @@ class Dataset(BaseModel):
         if harvest:
             # No type hints at runtime, we rely on TYPE_MAP being correct
             for k, v in harvest.items():
-                t = HarvestInfo.__annotations__[str(k)]
-                info[k] = Dataset.TYPE_MAP[t](v)
+                t = HarvestInfo.__annotations__.get(str(k))
+                if t:
+                    info[k] = Dataset.TYPE_MAP[t](v)
+
         return info
 
     def get_license_title(self, id: str | None) -> str | None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 import pytest
 
@@ -194,12 +195,19 @@ def test_base_model_harvest_spread(payload_ok):
     actual = base.to_row()
 
     expected = {
-        "harvest__created_at": "2013-02-16T00:00:00+00:00",
+        "harvest__backend": "CSW-DCAT",
+        "harvest__created_at": datetime.fromisoformat("2013-02-16T00:00:00+00:00"),
+        "harvest__dct_identifier": "4b112795-181a-4af5-9f66-c0837f50cbfa",
+        "harvest__domain": "catalogue.geo-ide.developpement-durable.gouv.fr",
+        "harvest__last_update": datetime.fromisoformat("2024-05-24T02:52:01.047000+00:00"),
+        # no modified_at
         "harvest__remote_id": "4b112795-181a-4af5-9f66-c0837f50cbfa",
         "harvest__remote_url": "https://catalogue.geo-ide.developpement-durable.gouv.fr:8443//catalogue/resource/4b112795-181a-4af5-9f66-c0837f50cbfa",
+        "harvest__source_id": "65390755494c3b6fb40892ec",
+        "harvest__uri": "https://catalogue.geo-ide.developpement-durable.gouv.fr:8443//catalogue/resource/4b112795-181a-4af5-9f66-c0837f50cbfa",
     }
 
-    assert actual | expected == actual
+    assert {k: v for k, v in actual.items() if k.startswith("harvest__")} == expected
 
 
 def test_base_model_harvest_spread_with_harvest_none(payload_ok):


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/410

```
demo=# \d catalog
                                                 Table "public.catalog"
            Column            |            Type             | Collation | Nullable |               Default               
------------------------------+-----------------------------+-----------+----------+-------------------------------------
 ...
 harvest__backend             | text                        |           |          | 
 harvest__source_id           | text                        |           |          | 
 harvest__remote_id           | text                        |           |          | 
 harvest__domain              | text                        |           |          | 
 harvest__last_update         | timestamp without time zone |           |          | 
 harvest__remote_url          | text                        |           |          | 
 harvest__uri                 | text                        |           |          | 
 harvest__dct_identifier      | text                        |           |          | 
 harvest__created_at          | timestamp without time zone |           |          | 
 harvest__modified_at         | timestamp without time zone |           |          | 
```

```
demo=# select dataset_id, harvest__source_id, harvest__created_at, harvest__modified_at, harvest__last_update from catalog limit 2;
        dataset_id        |    harvest__source_id    | harvest__created_at | harvest__modified_at |  harvest__last_update   
--------------------------+--------------------------+---------------------+----------------------+-------------------------
 6707388aeabdb61dd47ed652 | 6703b4870724a55efd609b84 | 2023-03-01 00:00:00 | 2023-01-24 00:00:00  | 2024-10-18 00:18:55.147
 6707388aeabdb61dd47ed651 | 6703b4870724a55efd609b84 | 2022-05-25 00:00:00 | 2023-01-24 00:00:00  | 2024-10-18 00:18:55.095
```