### PR TITLE
feat: Treat empty as missing in exists checks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -182,12 +182,13 @@ def compute_metrics():
         add_metric("avg_quality__score", compute_quality_score(org), organization=org)
 
         for indicator in Dataset.indicators:
+            field = indicator["field"]
             query = {
                 "deleted": False,
-                f"has_{indicator['id']}": True,
+                f"has_{field}": True,
                 "organization": org,
             }
-            measurement = f"nb_{indicator['id']}"
+            measurement = f"nb_{field}"
             value = catalog.count(**query)
             add_metric(measurement, value, organization=org)
             agg[measurement] += value

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,49 +33,49 @@ def test_base_model_get_attr_by_path_find_sub_property():
 
 def test_base_model_get_indicators_false():
     base = BaseModel({"column_false": None}, prefix="test")
-    base.indicators = [{"id": "column_false", "not": None}]
+    base.indicators = [{"field": "column_false", "exclude": (None,)}]
 
     assert base.get_indicators() == {"has_column_false": False}
 
     base = BaseModel({"column_false": True}, prefix="test")
-    base.indicators = [{"id": "column_false", "not": True}]
+    base.indicators = [{"field": "column_false", "exclude": (True,)}]
 
     assert base.get_indicators() == {"has_column_false": False}
 
     base = BaseModel({"column_false": "specific string"}, prefix="test")
-    base.indicators = [{"id": "column_false", "not": "specific string"}]
+    base.indicators = [{"field": "column_false", "exclude": ("specific string",)}]
 
     assert base.get_indicators() == {"has_column_false": False}
 
     base = BaseModel({"column_false": []}, prefix="test")
-    base.indicators = [{"id": "column_false", "not": [[], None]}]
+    base.indicators = [{"field": "column_false", "exclude": ([], None)}]
 
     assert base.get_indicators() == {"has_column_false": False}
 
     base = BaseModel({"column_false": None}, prefix="test")
-    base.indicators = [{"id": "column_false", "not": [[], None]}]
+    base.indicators = [{"field": "column_false", "exclude": ([], None)}]
 
     assert base.get_indicators() == {"has_column_false": False}
 
 
 def test_base_model_get_indicators_true():
     base = BaseModel({"column_one": "some value"}, prefix="test")
-    base.indicators = [{"id": "column_one", "not": None}]
+    base.indicators = [{"field": "column_one", "exclude": (None,)}]
 
     assert base.get_indicators() == {"has_column_one": True}
 
     base = BaseModel({"column_one": ""}, prefix="test")
-    base.indicators = [{"id": "column_one", "not": None}]
+    base.indicators = [{"field": "column_one", "exclude": (None,)}]
 
     assert base.get_indicators() == {"has_column_one": True}
 
     base = BaseModel({"column_one": 0}, prefix="test")
-    base.indicators = [{"id": "column_one", "not": None}]
+    base.indicators = [{"field": "column_one", "exclude": (None,)}]
 
     assert base.get_indicators() == {"has_column_one": True}
 
     base = BaseModel({"column_one": []}, prefix="test")
-    base.indicators = [{"id": "column_one", "not": None}]
+    base.indicators = [{"field": "column_one", "exclude": (None,)}]
 
     assert base.get_indicators() == {"has_column_one": True}
 


### PR DESCRIPTION
In most cases, it makes more sense to consider an empty string element (such as title, description, labels, ...) as missing instead of displaying an empty placeholder amongst other values.

In the rare cases we need to distinguish the two for a string type, we can explicitly use `exists(... exclude=(None,))`.