### PR TITLE
feat: add Organization.type from universe

### DIFF
--- a/alembic/versions/b99ee027d14f_add_organization_type.py
+++ b/alembic/versions/b99ee027d14f_add_organization_type.py
@@ -1,0 +1,27 @@
+"""add Organization.type
+
+Revision ID: b99ee027d14f
+Revises: af780a5cffbe
+Create Date: 2024-12-05 15:31:18.152913
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b99ee027d14f"
+down_revision: Union[str, None] = "af780a5cffbe"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("organizations", sa.Column("type", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "type")

--- a/alembic/versions/b99ee027d14f_add_organization_type.py
+++ b/alembic/versions/b99ee027d14f_add_organization_type.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "b99ee027d14f"
-down_revision: Union[str, None] = "af780a5cffbe"
+down_revision: Union[str, None] = "c9fc31256367"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/b99ee027d14f_add_organization_type.py
+++ b/alembic/versions/b99ee027d14f_add_organization_type.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "b99ee027d14f"
-down_revision: Union[str, None] = "c9fc31256367"
+down_revision: Union[str, None] = "ccdd23b19763"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/cli.py
+++ b/cli.py
@@ -46,7 +46,7 @@ class App:
 app = App()
 
 
-def load_organizations_custom(env: str) -> list[CustomOrganization]:
+def load_custom_organizations(env: str) -> list[CustomOrganization]:
     r = requests.get(get_config_value(env, "org_api"))
     r.raise_for_status()
     return [CustomOrganization.from_payload(o) for o in r.json()]
@@ -77,7 +77,7 @@ def update_organizations(env: str = "demo"):
     """Refresh and complement organizations"""
     print("Updating organizations...")
     organizations = app.session.query(Organization).all()
-    custom_organizations = load_organizations_custom(env)
+    custom_organizations = load_custom_organizations(env)
     for organization in organizations:
         fresh_organization = load_organization(env, organization.organization_id, refresh=True)
         if not fresh_organization:

--- a/cli.py
+++ b/cli.py
@@ -19,10 +19,10 @@ from metrics import compute_quality_score
 from models import (
     Base,
     Bouquet,
-    CustomOrganization,
     Dataset,
     DatasetBouquet,
     DatasetComputedColumns,
+    EcospheresUniverseOrganization,
     Metric,
     Organization,
     Resource,
@@ -46,10 +46,10 @@ class App:
 app = App()
 
 
-def load_custom_organizations(env: str) -> list[CustomOrganization]:
+def load_es_universe_organizations(env: str) -> list[EcospheresUniverseOrganization]:
     r = requests.get(get_config_value(env, "org_api"))
     r.raise_for_status()
-    return [CustomOrganization.from_payload(o) for o in r.json()]
+    return [EcospheresUniverseOrganization.from_payload(o) for o in r.json()]
 
 
 def load_organization(env: str, organization_id: str, refresh: bool = False) -> Organization | None:
@@ -77,7 +77,7 @@ def update_organizations(env: str = "demo"):
     """Refresh and complement organizations"""
     print("Updating organizations...")
     organizations = app.session.query(Organization).all()
-    custom_organizations = load_custom_organizations(env)
+    custom_organizations = load_es_universe_organizations(env)
     for organization in organizations:
         fresh_organization = load_organization(env, organization.organization_id, refresh=True)
         if not fresh_organization:

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ class ConfigDict(TypedDict):
     topic_slug: str
     prefix: str
     dsn: str
+    org_api: str
     stats_url: str | None
     stats_site_id: str | None
     stats_token: str | None
@@ -21,6 +22,8 @@ ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
         "stats_url": "https://stats.data.gouv.fr/index.php",
         "stats_site_id": "299",
         "stats_token": os.getenv("STATS_TOKEN", ""),
+        # FIXME: move to main branch when available
+        "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/feat/org-api/dist/organizations-prod.json",
     },
     "demo": {
         "universe_name": "ecospheres",
@@ -30,6 +33,8 @@ ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
         "stats_url": None,
         "stats_site_id": None,
         "stats_token": None,
+        # FIXME: move to main branch when available
+        "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/feat/org-api/dist/organizations-demo.json",
     },
 }
 

--- a/config.py
+++ b/config.py
@@ -22,8 +22,7 @@ ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
         "stats_url": "https://stats.data.gouv.fr/index.php",
         "stats_site_id": "299",
         "stats_token": os.getenv("STATS_TOKEN", ""),
-        # FIXME: move to main branch when available
-        "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/feat/org-api/dist/organizations-prod.json",
+        "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/main/dist/organizations-prod.json",
     },
     "demo": {
         "universe_name": "ecospheres",
@@ -33,8 +32,7 @@ ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
         "stats_url": None,
         "stats_site_id": None,
         "stats_token": None,
-        # FIXME: move to main branch when available
-        "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/feat/org-api/dist/organizations-demo.json",
+        "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/main/dist/organizations-demo.json",
     },
 }
 

--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date, datetime
-from typing import List, Optional
+from typing import List, Optional, TypedDict
 
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -297,6 +297,15 @@ class Resource(Base):
         )
 
 
+class CustomOrganization(TypedDict):
+    """An Organization from custom organizations API"""
+
+    id: str
+    name: str
+    slug: str
+    type: str
+
+
 class Organization(Base):
     __tablename__ = "organizations"
 
@@ -305,6 +314,7 @@ class Organization(Base):
     name: Mapped[str]
     acronym: Mapped[Optional[str]]
     service_public: Mapped[bool]
+    type: Mapped[Optional[str]]
 
     # relationships
     datasets: Mapped[List["Dataset"]] = relationship(

--- a/models.py
+++ b/models.py
@@ -299,8 +299,8 @@ class Resource(Base):
 
 
 @dataclass
-class CustomOrganization:
-    """An Organization from custom organizations API"""
+class EcospheresUniverseOrganization:
+    """Organization properties from our ecospheres-universe API"""
 
     id: str
     name: str
@@ -308,7 +308,7 @@ class CustomOrganization:
     type: str
 
     @classmethod
-    def from_payload(cls, payload: dict) -> "CustomOrganization":
+    def from_payload(cls, payload: dict) -> "EcospheresUniverseOrganization":
         return cls(
             id=payload["id"],
             name=payload["name"],

--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 import re
+from dataclasses import dataclass
 from datetime import date, datetime
-from typing import List, Optional, TypedDict
+from typing import List, Optional
 
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -297,13 +298,23 @@ class Resource(Base):
         )
 
 
-class CustomOrganization(TypedDict):
+@dataclass
+class CustomOrganization:
     """An Organization from custom organizations API"""
 
     id: str
     name: str
     slug: str
     type: str
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "CustomOrganization":
+        return cls(
+            id=payload["id"],
+            name=payload["name"],
+            slug=payload["slug"],
+            type=payload["type"],
+        )
 
 
 class Organization(Base):


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-dashboard-backend/issues/25
Depends on https://github.com/ecolabdata/ecospheres-universe/pull/7

Ajoute `Organization.type` depuis l'API exposée dans https://github.com/ecolabdata/ecospheres-universe/pull/7.

S'occupe aussi de "rafraichir" les infos des organisations depuis l'API de data.gouv.fr.

Je suis parti du principe qu'on gérera les libellés dans Grist plutôt que via un mapping ici (i.e. écrire "Direction Régionale" plutôt que DR dans le Grist, qui permet de gérer facilement des listes de valeurs).