### PR TITLE
feat: Faster loading

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -183,7 +183,7 @@ def load(
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         tasks = []
 
-        for dataset in iter_rel(topic["datasets"]):
+        for dataset in iter_rel(topic["datasets"], page_size=200):
             future = executor.submit(
                 process_dataset,
                 env,

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import math
+import re
 import time
 from typing import TypeAlias, TypedDict, TypeVar
 
@@ -30,8 +31,10 @@ class Rel(TypedDict):
     href: str
 
 
-def iter_rel(rel: Rel, quiet: bool = False):
+def iter_rel(rel: Rel, quiet: bool = False, page_size: int | None = None):
     current_url = rel["href"]
+    if page_size:
+        current_url = re.sub(r"page_size=(?:[0-9]+)", f"page_size={page_size}", current_url)
     if not quiet:
         print(f"Fetching {current_url}...")
     while current_url is not None:


### PR DESCRIPTION
Increase `page_size` to maximize data.gouv `topics/<topic>/datasets` throughput.

Value was picked by manually testing various pages sizes in the browser and picking a good-looking stat.

Throughput increases up to page sizes around 200 then drops, but somewhat unexpectedly re-increases around 1000. The difference isn't large, so I went for shorter request times (2.5s at 200, 11s at 1000) to minimize the risk of timeouts or other network interruptions.

45 ~> 8 mn :sunglasses: 