### PR TITLE
fix: session rollback on process_dataset error and log to sentry

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -134,10 +134,10 @@ def load_bouquets(env: str = "demo", include_private: bool = False):
 def process_dataset(env: str, d: dict, licenses: list, skip_related: bool) -> None:
     """Process a single dataset and its resources"""
     prefix = get_config_value(env, "prefix")
-    if organization_id := (d.get("organization") or {}).get("id"):
-        load_organization(env, organization_id)
-
     try:
+        if organization_id := (d.get("organization") or {}).get("id"):
+            load_organization(env, organization_id)
+
         dataset_obj = Dataset.from_payload(d, prefix, licenses)
         existing = app.session.query(Dataset).filter_by(dataset_id=dataset_obj.dataset_id).first()
         upsert(app.session, dataset_obj, existing)

--- a/cli.py
+++ b/cli.py
@@ -149,6 +149,8 @@ def process_dataset(env: str, d: dict, licenses: list, skip_related: bool) -> No
             app.session.commit()
     except Exception as e:
         app.session.rollback()
+        if sentry_sdk:
+            sentry_sdk.capture_exception(e)
         raise e
 
 

--- a/cli.py
+++ b/cli.py
@@ -149,7 +149,7 @@ def process_dataset(env: str, d: dict, licenses: list, skip_related: bool) -> No
             app.session.commit()
     except Exception as e:
         app.session.rollback()
-        if sentry_sdk:
+        if sentry_dsn:
             sentry_sdk.capture_exception(e)
         raise e
 


### PR DESCRIPTION
This avoids numerous [`PendingRollbackError`](https://ecolab-et.sentry.io/issues/46861071/?project=4508414580031568&query=&referrer=issue-stream&stream_index=0) if something goes wrong when processing a dataset ([such as an invalid JSON insertion](https://ecolab-et.sentry.io/issues/46861070/?project=4508414580031568&query=&referrer=issue-stream&stream_index=1)).

I still need to protect against invalid JSON ~~and correctly report errors to Sentry (somehow it's less than trivial in a thread context)~~, but this simple fix should allow the script to handle the datasets that aren't in error.