### PR TITLE
fix: get Bouquet.theme from tags

### DIFF
--- a/alembic/versions/cd7258fee3ae_add_bouquet_theme.py
+++ b/alembic/versions/cd7258fee3ae_add_bouquet_theme.py
@@ -1,0 +1,27 @@
+"""Add Bouquet.theme
+
+Revision ID: cd7258fee3ae
+Revises: eb04e2618b0f
+Create Date: 2025-06-30 12:06:33.864018
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "cd7258fee3ae"
+down_revision: Union[str, None] = "eb04e2618b0f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("bouquets", sa.Column("theme", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("bouquets", "theme")

--- a/cli.py
+++ b/cli.py
@@ -193,7 +193,7 @@ def update_organizations(env: str = "demo"):
 
 
 @cli
-def load_bouquets(env: str = "demo"):
+def load_bouquets(env: str = "demo", include_private: bool = False):
     prefix = get_config_value(env, "prefix")
 
     # build a pallatable list of themes from remote config
@@ -214,6 +214,8 @@ def load_bouquets(env: str = "demo"):
 
     universe_name = get_config_value(env, "universe_name")
     url = f"https://{prefix}.data.gouv.fr/api/2/topics/?tag={universe_name}"
+    if include_private:
+        url = f"{url}&include_private=yes"
 
     for bouquet in iter_rel(
         {
@@ -313,7 +315,7 @@ def load(
 
     if not skip_related:
         update_organizations(env=env)
-        load_bouquets(env=env)
+        load_bouquets(env=env, include_private=True)
 
     if not skip_metrics:
         # we're loading metrics from last month, only run on the second of the month

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import date, timedelta
 from threading import Lock
-from typing import Callable, Literal, NamedTuple
+from typing import Callable, NamedTuple
 
 import requests
 import sentry_sdk
@@ -199,10 +199,9 @@ def load_bouquets(env: str = "demo", include_private: bool = False):
     # build a pallatable list of themes from remote config
     page_config = get_front_config(env)["pages"]["bouquets"]
     raw_themes = next((f for f in page_config["filters"] if f["id"] == "theme"), {"values": []})
-    themes: list[dict[Literal["id", "name"], str]] = [
-        {"id": f"{page_config['tag_prefix']}-theme-{t['id']}", "name": t["name"]}
-        for t in raw_themes["values"]
-    ]
+    themes = {
+        f"{page_config['tag_prefix']}-theme-{t['id']}": t["name"] for t in raw_themes["values"]
+    }
 
     app.session.execute(text("DELETE FROM datasets_bouquets"))
     app.session.commit()

--- a/config.py
+++ b/config.py
@@ -1,6 +1,9 @@
 import os
 from typing import Literal, TypedDict
 
+import requests
+from yaml import safe_load
+
 
 class ConfigDict(TypedDict):
     universe_name: str
@@ -12,6 +15,7 @@ class ConfigDict(TypedDict):
     stats_site_id: str | None
     stats_token: str | None
     metrics_api_url: str | None
+    front_config_file: str | None
 
 
 ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
@@ -25,6 +29,7 @@ ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
         "stats_token": os.getenv("STATS_TOKEN", ""),
         "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/main/dist/organizations-prod.json",
         "metrics_api_url": "https://metric-api.data.gouv.fr/api",
+        "front_config_file": "https://raw.githubusercontent.com/opendatateam/udata-front-kit/refs/heads/ecospheres-prod/configs/ecospheres/config.yaml",
     },
     "demo": {
         "universe_name": "ecospheres",
@@ -36,6 +41,7 @@ ENVS_CONF: dict[Literal["prod", "demo"], ConfigDict] = {
         "stats_token": None,
         "org_api": "https://raw.githubusercontent.com/ecolabdata/ecospheres-universe/refs/heads/main/dist/organizations-demo.json",
         "metrics_api_url": None,
+        "front_config_file": "https://raw.githubusercontent.com/opendatateam/udata-front-kit/refs/heads/main/configs/ecospheres/config.yaml",
     },
 }
 
@@ -46,3 +52,10 @@ def get_config_value(env: str, key: str) -> str:
     if key not in ENVS_CONF[env]:
         raise ValueError(f"Invalid config key '{key}' for environment '{env}'.")
     return ENVS_CONF[env][key]
+
+
+def get_front_config(env: str) -> dict:
+    config_file = get_config_value(env, "front_config_file")
+    r = requests.get(config_file)
+    r.raise_for_status()
+    return safe_load(r.content)

--- a/models.py
+++ b/models.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -389,9 +389,7 @@ class Bouquet(Base):
         return f"<Bouquet {self.bouquet_id}>"
 
     @classmethod
-    def from_payload(
-        cls, payload: dict, themes: list[dict[Literal["id", "name"], str]]
-    ) -> "Bouquet":
+    def from_payload(cls, payload: dict, themes: dict[str, str]) -> "Bouquet":
         data = payload.copy()
         data["deleted"] = False
 
@@ -399,7 +397,7 @@ class Bouquet(Base):
         data["bouquet_id"] = data.pop("id")
         data["organization"] = data["organization"]["id"] if data["organization"] else None
         data["owner"] = data["owner"]["id"] if data["owner"] else None
-        data["theme"] = next((t["name"] for t in themes if t["id"] in data["tags"]), None)
+        data["theme"] = next((themes[tid] for tid in themes if tid in data["tags"]), None)
 
         datasets_properties = data["extras"]["ecospheres"]["datasets_properties"]
         data["nb_datasets"] = len([d for d in datasets_properties if d.get("id")])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ gunicorn
 alembic
 sentry-sdk
 progressist
+PyYAML

--- a/tests/fixtures/bouquet_payload_ok.json
+++ b/tests/fixtures/bouquet_payload_ok.json
@@ -1,0 +1,104 @@
+{
+    "id": "682d942102634f7cc798472e",
+    "name": "Les donn\u00e9es de mobilit\u00e9 du Cerema",
+    "slug": "les-donnees-de-mobilite-du-cerema",
+    "description": "Le Cerema g\u00e8re, produit et publie plusieurs jeux de donn\u00e9es sur data.gouv.fr. L'objectif de ce bouquet est d'y donner un acc\u00e8s en un clic. Ce bouquet liste les quelques datasets qui sont actualis\u00e9s au fil de l'eau ou chaque ann\u00e9e. Les donn\u00e9es du Cerema publi\u00e9s sur data gouv comprennent aussi des jeux donn\u00e9es historiques, qui ne sont pas mis \u00e0 jour. Pour les trouver : [page data.gouv](https://www.data.gouv.fr/fr/organizations/cerema/datasets/?page_size=20&tag=mobilite)\n",
+    "tags": [
+        "ecospheres-subtheme-mobilite-courte-distance-hors-voiture",
+        "ecospheres-theme-mieux-se-deplacer",
+        "univers-ecospheres"
+    ],
+    "datasets": {
+        "rel": "subsection",
+        "href": "https://www.data.gouv.fr/api/2/topics/682d942102634f7cc798472e/datasets/?page=1&page_size=20",
+        "type": "GET",
+        "total": 6
+    },
+    "reuses": {
+        "rel": "subsection",
+        "href": "https://www.data.gouv.fr/api/2/topics/682d942102634f7cc798472e/reuses/?page=1&page_size=20",
+        "type": "GET",
+        "total": 0
+    },
+    "featured": false,
+    "private": false,
+    "created_at": "2025-05-21T08:51:45.755000+00:00",
+    "spatial": {
+        "geom": null,
+        "zones": [
+            "country:fr"
+        ],
+        "granularity": "other"
+    },
+    "last_modified": "2025-05-27T13:08:55.224000+00:00",
+    "organization": {
+        "name": "Cerema",
+        "acronym": "Cerema",
+        "uri": "https://www.data.gouv.fr/api/1/organizations/cerema/",
+        "slug": "cerema",
+        "page": "https://www.data.gouv.fr/fr/organizations/cerema/",
+        "logo": "https://static.data.gouv.fr/avatars/6e/aa2d032798425bbf880a15dc2afcd0-original.jpg",
+        "logo_thumbnail": "https://static.data.gouv.fr/avatars/6e/aa2d032798425bbf880a15dc2afcd0-100.jpg",
+        "badges": [
+            {
+                "kind": "public-service"
+            },
+            {
+                "kind": "certified"
+            }
+        ],
+        "id": "5c812a16634f416583ed1876",
+        "class": "Organization"
+    },
+    "owner": null,
+    "uri": "https://www.data.gouv.fr/api/1/topics/les-donnees-de-mobilite-du-cerema/",
+    "page": "https://www.data.gouv.fr/fr/topics/les-donnees-de-mobilite-du-cerema/",
+    "extras": {
+        "ecospheres": {
+            "datasets_properties": [
+                {
+                    "title": "Base des Plans de Mobilit\u00e9 (PDM) et PDM simplifi\u00e9s",
+                    "purpose": "Donn\u00e9e Cerema",
+                    "availability": "available",
+                    "uri": "/datasets/67628c81ed433f189a30bc8c",
+                    "id": "67628c81ed433f189a30bc8c"
+                },
+                {
+                    "title": "Liste et composition des Autorit\u00e9s Organisatrices de la Mobilit\u00e9",
+                    "purpose": "Donn\u00e9e Cerema",
+                    "availability": "available",
+                    "uri": "/datasets/5b90e9338b4c413448c4b22a",
+                    "id": "5b90e9338b4c413448c4b22a"
+                },
+                {
+                    "title": "Base Passim : offres, services d'info et donn\u00e9es de transport",
+                    "purpose": "Donn\u00e9e Cerema",
+                    "availability": "available",
+                    "uri": "/datasets/56e2d64cc751df38e81ffccd",
+                    "id": "56e2d64cc751df38e81ffccd"
+                },
+                {
+                    "title": "Avatar : plate-forme publique des donn\u00e9es de trafic des gestionnaires routiers",
+                    "purpose": "Donn\u00e9es Cerema",
+                    "availability": "available",
+                    "uri": "/datasets/6756b5d8b860bca4a985e633",
+                    "id": "6756b5d8b860bca4a985e633"
+                },
+                {
+                    "title": "Recensement des r\u00e9seaux de Bus \u00e0 Haut Niveau de Service",
+                    "purpose": "Donn\u00e9e Cerema",
+                    "availability": "available",
+                    "uri": "/datasets/671790490c0225d4c6d44548",
+                    "id": "671790490c0225d4c6d44548"
+                },
+                {
+                    "title": "Base des Installations Terminales Embranch\u00e9es (ITE 3000)",
+                    "purpose": "Donn\u00e9e Cerema",
+                    "availability": "available",
+                    "uri": "/datasets/67a4cccd5dd42fd46f273269",
+                    "id": "67a4cccd5dd42fd46f273269"
+                }
+            ]
+        }
+    }
+}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from models import Dataset, DatasetComputedColumns, ResourceComputedColumns
+from models import Bouquet, Dataset, DatasetComputedColumns, ResourceComputedColumns
 
 
 @pytest.fixture
@@ -263,3 +263,14 @@ def test_resource_model_indicators(fixture_payload):
     }
 
     assert actual | expected == actual  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "fixture_payload", ["bouquet_payload_ok.json"], indirect=["fixture_payload"]
+)
+def test_bouquet_theme(fixture_payload):
+    bouquet = Bouquet.from_payload(
+        fixture_payload,
+        themes=[{"id": "ecospheres-theme-mieux-se-deplacer", "name": "Mieux se déplacer"}],
+    )
+    assert bouquet.theme == "Mieux se déplacer"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -271,6 +271,6 @@ def test_resource_model_indicators(fixture_payload):
 def test_bouquet_theme(fixture_payload):
     bouquet = Bouquet.from_payload(
         fixture_payload,
-        themes=[{"id": "ecospheres-theme-mieux-se-deplacer", "name": "Mieux se déplacer"}],
+        themes={"ecospheres-theme-mieux-se-deplacer": "Mieux se déplacer"},
     )
     assert bouquet.theme == "Mieux se déplacer"


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/559

Introduces `Bouquet.theme`, fed from Topic tags correlated with front config reference list of values.

The chart on superset will need to be updated.