### PR TITLE
fix: Exclude dicts with only null values as part of DEFAULT_JSON_EXCLUDE

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,10 +9,13 @@ from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-DEFAULT_EXCLUDE = (None,)
-DEFAULT_LIST_EXCLUDE = (None, [])
-DEFAULT_STRING_EXCLUDE = (None, "")
-DEFAULT_JSON_EXCLUDE = (None, {})
+from utils import (
+    DEFAULT_EXCLUDE,
+    DEFAULT_JSON_EXCLUDE,
+    DEFAULT_LIST_EXCLUDE,
+    DEFAULT_STRING_EXCLUDE,
+    accept,
+)
 
 
 class Bounds[T: (int, float)](NamedTuple):
@@ -32,10 +35,6 @@ class ContactPoint(NamedTuple):
 
 class Base(DeclarativeBase):
     pass
-
-
-def exists(element, exclude: tuple = DEFAULT_EXCLUDE):
-    return element not in exclude
 
 
 class DatasetComputedColumns:
@@ -94,7 +93,7 @@ class DatasetComputedColumns:
         for indicator in self.indicators:
             field = indicator["field"]
             value = self.get_attr_by_path(field)
-            indicators[f"has_{field}"] = exists(value, exclude=indicator["exclude"])
+            indicators[f"has_{field}"] = accept(value, exclude=indicator["exclude"])
         return indicators
 
     def get_prefix_or_fallback_from(self, key) -> str:
@@ -336,13 +335,13 @@ class ResourceComputedColumns:
 
     def get_indicators(self) -> dict:
         return {
-            "title__exists": exists(self.payload["title"], exclude=DEFAULT_STRING_EXCLUDE),
-            "description__exists": exists(
+            "title__exists": accept(self.payload["title"], exclude=DEFAULT_STRING_EXCLUDE),
+            "description__exists": accept(
                 self.payload["description"], exclude=DEFAULT_STRING_EXCLUDE
             ),
-            "type__exists": exists(self.payload["type"], exclude=DEFAULT_STRING_EXCLUDE),
-            "format__exists": exists(self.payload["format"], exclude=DEFAULT_STRING_EXCLUDE),
-            "schema__exists": exists(self.payload.get("schema"), exclude=DEFAULT_STRING_EXCLUDE),
+            "type__exists": accept(self.payload["type"], exclude=DEFAULT_STRING_EXCLUDE),
+            "format__exists": accept(self.payload["format"], exclude=DEFAULT_STRING_EXCLUDE),
+            "schema__exists": accept(self.payload.get("schema"), exclude=DEFAULT_JSON_EXCLUDE),
         }
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from collections.abc import Callable, Iterable
 from math import ulp
 
@@ -476,9 +477,26 @@ def test_resource_model_indicators(fixture_payload):
         "description__exists": False,
         "type__exists": True,
         "format__exists": False,
+        "schema__exists": False,
     }
 
     assert actual | expected == actual  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ({"schema": None}, False),
+        ({"schema": {"name": "foo", "url": None, "version": None}}, True),
+        ({"schema": {"name": None, "url": "http://example.com/foo", "version": None}}, True),
+        ({"schema": {"name": None, "url": None, "version": None}}, False),
+    ],
+)
+def test_resource_schema(payload, expected):
+    # using defaultdict so we don't have to specify all non-relevant but required resource keys
+    default_payload = defaultdict(lambda: None, payload)
+    actual = ResourceComputedColumns(default_payload).get_indicators()
+    assert actual["schema__exists"] == expected
 
 
 @pytest.mark.parametrize(

--- a/utils.py
+++ b/utils.py
@@ -1,18 +1,20 @@
 import math
 import re
 import time
-from typing import TypeAlias, TypedDict, TypeVar
+from collections.abc import Sequence
+from typing import Any, Protocol, TypedDict
 
 import requests
 from sqlalchemy.orm import scoped_session
 
-from models import Bouquet, Dataset, DatasetMetric, Metric, Organization, Resource, Stats
 
-Model: TypeAlias = Bouquet | Dataset | DatasetMetric | Metric | Organization | Resource | Stats
-T = TypeVar("T", bound=Model)
+class HasId(Protocol):
+    id: Any
 
 
-def upsert(session: scoped_session, new: T, existing: T | None, auto_commit: bool = True) -> T:
+def upsert[T: HasId](
+    session: scoped_session, new: T, existing: T | None, auto_commit: bool = True
+) -> T:
     if existing:
         new.id = existing.id
         session.merge(new)
@@ -55,3 +57,29 @@ def iter_rel(rel: Rel, quiet: bool = False, page_size: int | None = None):
         current_url = payload["next_page"]
         for d in payload["data"]:
             yield d
+
+
+def no_value_dict(obj: Any) -> bool:
+    return isinstance(obj, dict) and all([v is None for v in obj.values()])
+
+
+DEFAULT_EXCLUDE = (None,)
+DEFAULT_JSON_EXCLUDE = (None, {}, no_value_dict)
+DEFAULT_LIST_EXCLUDE = (None, [])
+DEFAULT_STRING_EXCLUDE = (None, "")
+
+
+def accept(element: Any, exclude: Sequence[Any] = DEFAULT_EXCLUDE) -> bool:
+    """
+    Return True if `element` is not in the `exclude` sequence, False otherwise.
+
+    The `exclude` sequence can contain:
+    - A value which should be excluded.
+    - A callable taking `element` as a single parameter and returning True iff `element` should be excluded.
+    """
+    for item in exclude:
+        if callable(item) and item(element):
+            return False
+        elif element == item:
+            return False
+    return True

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,32 @@ import requests
 from sqlalchemy.orm import scoped_session
 
 
+def no_value_dict(obj: Any) -> bool:
+    return isinstance(obj, dict) and all(v is None for v in obj.values())
+
+
+DEFAULT_EXCLUDE = (None,)
+DEFAULT_JSON_EXCLUDE = (None, {}, no_value_dict)
+DEFAULT_LIST_EXCLUDE = (None, [])
+DEFAULT_STRING_EXCLUDE = (None, "")
+
+
+def accept(element: Any, exclude: Sequence[Any] = DEFAULT_EXCLUDE) -> bool:
+    """
+    Return True if `element` is not in the `exclude` sequence, False otherwise.
+
+    The `exclude` sequence can contain:
+    - A value which should be excluded.
+    - A callable taking `element` as a single parameter and returning True iff `element` should be excluded.
+    """
+    for item in exclude:
+        if callable(item) and item(element):
+            return False
+        elif element == item:
+            return False
+    return True
+
+
 class HasId(Protocol):
     id: Any
 
@@ -57,29 +83,3 @@ def iter_rel(rel: Rel, quiet: bool = False, page_size: int | None = None):
         current_url = payload["next_page"]
         for d in payload["data"]:
             yield d
-
-
-def no_value_dict(obj: Any) -> bool:
-    return isinstance(obj, dict) and all([v is None for v in obj.values()])
-
-
-DEFAULT_EXCLUDE = (None,)
-DEFAULT_JSON_EXCLUDE = (None, {}, no_value_dict)
-DEFAULT_LIST_EXCLUDE = (None, [])
-DEFAULT_STRING_EXCLUDE = (None, "")
-
-
-def accept(element: Any, exclude: Sequence[Any] = DEFAULT_EXCLUDE) -> bool:
-    """
-    Return True if `element` is not in the `exclude` sequence, False otherwise.
-
-    The `exclude` sequence can contain:
-    - A value which should be excluded.
-    - A callable taking `element` as a single parameter and returning True iff `element` should be excluded.
-    """
-    for item in exclude:
-        if callable(item) and item(element):
-            return False
-        elif element == item:
-            return False
-    return True


### PR DESCRIPTION
This means `{"foo": None, "bar": None}` is considered as an empty dict and is excluded by default when checking whether a field "exists".

I had to refactor some unrelated stuff in utils.py to avoid circular dependencies.