### PR TITLE
fix: aggregated metrics storage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -372,45 +372,60 @@ def compute_metrics(env: str = "demo"):
         add_metric(app.session, agg_key, agg_value, organization=None)
 
     # global average quality score
-    add_metric(app.session, "avg_quality__score", compute_quality_score(app.session))
+    add_metric(
+        app.session, "avg_quality__score", compute_quality_score(app.session), organization=None
+    )
 
     # nb of associations bouquet <-> dataset from universe
     nb_datasets_bouquets = app.session.query(DatasetBouquet).count()
-    add_metric(app.session, "nb_datasets_from_universe_in_bouquets", nb_datasets_bouquets)
+    add_metric(
+        app.session,
+        "nb_datasets_from_universe_in_bouquets",
+        nb_datasets_bouquets,
+        organization=None,
+    )
 
     bouquets = app.session.query(Bouquet)
     add_metric(
-        app.session, "nb_bouquets_public", bouquets.filter_by(deleted=False, private=False).count()
+        app.session,
+        "nb_bouquets_public",
+        bouquets.filter_by(deleted=False, private=False).count(),
+        organization=None,
     )
     # nb_datasets_in_bouquets
     add_metric(
         app.session,
         "nb_datasets_in_bouquets_public",
         sum(b.nb_datasets for b in bouquets.filter_by(deleted=False, private=False)),
+        organization=None,
     )
     # nb_datasets_external_in_bouquets
     add_metric(
         app.session,
         "nb_datasets_external_in_bouquets_public",
         sum(b.nb_datasets_external for b in bouquets.filter_by(deleted=False, private=False)),
+        organization=None,
     )
     # nb_factors_in_bouquets
     add_metric(
         app.session,
         "nb_factors_in_bouquets_public",
         sum(b.nb_factors for b in bouquets.filter_by(deleted=False, private=False)),
+        organization=None,
     )
     # nb_factors_missing_in_bouquets
     add_metric(
         app.session,
         "nb_factors_missing_in_bouquets_public",
         sum(b.nb_factors_missing for b in bouquets.filter_by(deleted=False, private=False)),
+        organization=None,
     )
     # nb_factors_not_available_in_bouquets
     add_metric(
         app.session,
         "nb_factors_not_available_in_bouquets_public",
         sum(b.nb_factors_not_available for b in bouquets.filter_by(deleted=False, private=False)),
+        organization=None,
     )
 
 


### PR DESCRIPTION
Broken in #48 

Without this, the upsert logic would update the first metric value it comes across instead of creating one for `organization is null`.

TODO: try to backfill the values? Maybe take the max on all orgs (that should be the sum) and the value for the matched org should be max - sum(orgs).

