### PR TITLE
fix: Breaking on null factor element

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -236,7 +236,7 @@ def load_bouquets(env: str = "demo", include_private: bool = False):
 
 def process_factor(env: str, factor: dict, licenses: list, skip_related: bool) -> None:
     """Process a single factor (dataset) and its resources"""
-    if factor.get("element", {}).get("class") != "Dataset":
+    if (factor.get("element") or {}).get("class") != "Dataset":
         print(f"Skipping factor {factor['id']} (not a dataset).")
         return
     base_url = get_config_value(env, "base_url")


### PR DESCRIPTION
```
Failed to process dataset 68d4d332611f8207922f8648: 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/app/cli.py", line 317, in load
    task.future.result()
  File "/app/.heroku/python/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/app/.heroku/python/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/app/.heroku/python/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/cli.py", line 239, in process_factor
    if factor.get("element", {}).get("class") != "Dataset":
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```