### PR TITLE
fix: revert to old way of handling 429

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -566,6 +566,7 @@ def initialize(env: str):
             backoff_jitter=1,
             backoff_max=300,
             redirect=False,  # already handled by requests
+            status_forcelist={413, 503, 504},  # 429 not handled here
         )
     )
     app.req.mount("http://", adapter)

--- a/rel.py
+++ b/rel.py
@@ -1,5 +1,6 @@
 import math
 import re
+import time
 from logging import Logger
 from typing import TypedDict
 
@@ -25,8 +26,17 @@ def iter_rel(
     if log:
         log.info(f"Fetching {current_url}...")
     while current_url is not None:
-        r = s.get(current_url, headers=headers)
-        r.raise_for_status()
+        while True:
+            r = s.get(current_url, headers=headers)
+            if not r.ok:
+                if r.status_code == 429:
+                    if log:
+                        log.warning("429 hit, waiting a bit")
+                    time.sleep(10)
+                    continue
+                else:
+                    r.raise_for_status()
+            break
         payload = r.json()
         total_pages = math.ceil(payload["total"] / payload["page_size"])
         if log:


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres-dashboard-backend/issues/86 (hopefully)

Revert to handling 429 manually since urllib3 Retry is too aggressive.

There is still a possibility the multiple threads get too many 429 in a short time and cause a ban, but the proper fix is pretty involved. So let's wait and see if it's really needed.

At least this fix should make the job work most of the time :crossed_fingers: 